### PR TITLE
Add prompt for WaniKani API Token

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
     "env": {
         "browser": true,
-        "es2021": true
+        "es2021": true,
+        "greasemonkey": true
     },
     "extends": [
         "eslint:recommended",

--- a/NhkEasyPracticeWithWaniKani.user.js
+++ b/NhkEasyPracticeWithWaniKani.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name          NHK Easy Practice With WaniKani
 // @namespace     https://github.com/entropyofchaos/NHK-Easy-Practice-With-WaniKani
-// @version       0.1
+// @version       0.2
 // @description   Dynamically hides furigana on NHK Easy website based on a user's Kanji and Vocabulary that are at at least Guru 1.
 //                Also works with hiragana.jp which attempts to add furigana to any Japanese website.
 // @author        Brian Lichtman

--- a/README.md
+++ b/README.md
@@ -5,6 +5,4 @@ https://github.com/entropyofchaos/NHK-Easy-Practice-With-WaniKani/raw/main/NhkEa
 
 Alternatively, you can click on the script NhkEasyPracticeWithWaniKani.user.js and then click the Raw button.
 
-Once the script is installed using a script manager like Tampermonkey, you will need to edit the script and insert your WaniKani Version 2 API token into the script.
-
-Specific details on how to do this will be added to the readme in the future.
+Once the script is installed using a script manager like Tampermonkey, you will be prompted to enter your WaniKani API Token when loading NHK News.


### PR DESCRIPTION
This pull request will prompt the user to input their WaniKani API Token when the page first loads as opposed to hard coding the token in the user script. The token will be stored as a user script value so they won't have to enter it every time a new page is loaded. The user script will also validate the token before storing it (just by hitting an arbitrary endpoint in the WaniKani API and making sure the response is OK).

I'm not certain if this feature is necessary, but I figured it would be a little bit easier for people who aren't familiar with scripts. Let me know if there are any issues with the PR.