### PR TITLE
Remove the furigana from known vocab in NHK Easy's pop-up dictionary

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,9 @@ module.exports = {
         "eslint:recommended",
         "plugin:react/recommended"
     ],
+    "globals": {
+        "g_dic": "writeable"
+    },
     "parserOptions": {
         "ecmaFeatures": {
             "jsx": true

--- a/NhkEasyPracticeWithWaniKani.user.js
+++ b/NhkEasyPracticeWithWaniKani.user.js
@@ -68,8 +68,8 @@ function findRubyInPage(knownVocab) {
 }
 
 /**
- * Finds the Ruby tags in NHK Easy's pop-up dictionary and replaces them with 
- * just the word if the word is in the known set of vocabulary.
+ * Finds the Ruby tags in NHK Easy's pop-up dictionary and hides the tags
+ * that match words in the passed in set of known vocabulary.
  * @param {Set} knownVocab Set of all vocab that has been learned on WK
  */
 function findRubyInDictionary(knownVocab) {
@@ -79,7 +79,9 @@ function findRubyInDictionary(knownVocab) {
     g_dic.reikai.entries[entryKey].map(entryValues => {
       entryValues.def = entryValues.def.replaceAll(
         rubyElementMatcherExp,
-        (rubyElement, word) => knownVocab.has(word) ? word : rubyElement
+        (rubyElement, word) => knownVocab.has(word)
+          ? rubyElement.replace("<rt>", "<rt style=\"visibility: hidden;\">")
+          : rubyElement
       );
 
       return entryValues;


### PR DESCRIPTION
It looks like the pop-up dictionary text is loaded from a javascript object called g_dic, as opposed to being loaded directly from the page's HTML. The text entries on that object still have the ruby tags, so the find and replace process is pretty similar to the existing one.

If there are any issues with the pull request let me know.